### PR TITLE
Remove custom import ordering from styleguide

### DIFF
--- a/src/main/resources/hmcts-checkstyle.xml
+++ b/src/main/resources/hmcts-checkstyle.xml
@@ -182,11 +182,6 @@
     </module>
     <module name="OverloadMethodsDeclarationOrder"/>
     <module name="VariableDeclarationUsageDistance"/>
-    <module name="CustomImportOrder">
-      <property name="sortImportsInGroupAlphabetically" value="true"/>
-      <property name="separateLineBetweenGroups" value="true"/>
-      <property name="customImportOrderRules" value="THIRD_PARTY_PACKAGE###STANDARD_JAVA_PACKAGE###STATIC"/>
-    </module>
     <module name="MethodParamPad"/>
     <module name="NoWhitespaceBefore">
       <property name="tokens" value="COMMA, SEMI, POST_INC, POST_DEC, DOT, ELLIPSIS, METHOD_REF"/>


### PR DESCRIPTION
### Change description ###

There has not been a consistent import ordering applied to HMCTS projects, making it impractical to be consistent retrospectively.



