### PR TITLE
Preserve CDATA tags in cleaned suppressions xml

### DIFF
--- a/src/test/groovy/uk.gov.hmcts/Test.groovy
+++ b/src/test/groovy/uk.gov.hmcts/Test.groovy
@@ -1,5 +1,7 @@
 package uk.gov.hmcts
 
+import groovy.xml.XmlUtil
+import org.w3c.dom.Element
 import spock.lang.Specification
 import uk.gov.hmcts.tools.DependencyCheckSetup
 
@@ -7,7 +9,7 @@ class Test extends Specification {
 
     def "extracts set of CVEs from suppression report"() {
         given:
-        def xml = this.getClass().getResource( '/dependency_checker_report_for_redundant_suppressions.xml' ).text
+        def xml = this.getClass().getResource('/dependency_checker_report_for_redundant_suppressions.xml').text
 
         when:
         def cves = DependencyCheckSetup.getSuppressedCves(xml)
@@ -26,15 +28,17 @@ class Test extends Specification {
 
     def "filters out unused suppressions"() {
         given:
-        def xml = this.getClass().getResource( '/has_redundant_suppressions.xml' ).text
+        def xml = this.getClass().getResource('/has_redundant_suppressions.xml').text
         def cves = [
                 "CVE-2018-1258"
         ]
         when:
-        def suppressions = DependencyCheckSetup.stripUnusedSuppressions(xml, cves)
+        Element suppressions = DependencyCheckSetup.stripUnusedSuppressions(xml, cves)
 
         then:
         // See the suppressions file which has 4 suppressions referencing CVE-2018-1258.
-        suppressions.children().size() == 4
+        suppressions.getChildNodes().getLength() == 4
+        // Preserves these data tags on reserialisation.
+        XmlUtil.serialize(suppressions).contains "<![CDATA["
     }
 }


### PR DESCRIPTION
### Change description ###

CDATA tags are used by the dependency checker in its generated xml; stripping them out generates a noisy diff.

